### PR TITLE
Repositoryの実装(roomのみを想定）

### DIFF
--- a/app/src/main/java/jp/co/cyberagent/dojo2020/data/Repository.kt
+++ b/app/src/main/java/jp/co/cyberagent/dojo2020/data/Repository.kt
@@ -3,12 +3,16 @@ package jp.co.cyberagent.dojo2020.data
 import jp.co.cyberagent.dojo2020.data.model.Memo
 import kotlinx.coroutines.flow.Flow
 
-class Repository(private val localDataSource: DataSource, private val remoteDataSource: DataSource) : DataSource {
+class Repository(
+    private val localDataSource: DataSource,
+    private val remoteDataSource: DataSource
+) : DataSource {
+
     override suspend fun save(memo: Memo) {
-        TODO("Not yet implemented")
+        localDataSource.save(memo)
     }
 
     override suspend fun fetchAll(): Flow<List<Memo>> {
-        TODO("Not yet implemented")
+        return localDataSource.fetchAll()
     }
 }


### PR DESCRIPTION
・行ったこと
Repositoryを実装した

・行った理由
LocalDataSourceの実装が完了したのと、ViewModelの実装でRepositoryがあると都合がよいから

・どのようにして行ったか
RepositoryでLocalDataSourceを操作することで実現している。
