### PR TITLE
DraftとMemoをTextとして扱えるようにする

### DIFF
--- a/app/src/main/java/jp/co/cyberagent/dojo2020/data/model/Text.kt
+++ b/app/src/main/java/jp/co/cyberagent/dojo2020/data/model/Text.kt
@@ -1,0 +1,14 @@
+package jp.co.cyberagent.dojo2020.data.model
+
+sealed class Text(
+    val id: String,
+    val title: String,
+    val contents: String,
+    val category: String
+)
+
+data class Left(val value: Draft) : Text(value.id, value.title, value.content, value.category)
+data class Right(val value: Memo) : Text(value.id, value.title, value.contents, value.category)
+
+fun Draft.toText(): Text = Left(this)
+fun Memo.toText(): Text = Right(this)

--- a/app/src/main/java/jp/co/cyberagent/dojo2020/ui/TextAdapter.kt
+++ b/app/src/main/java/jp/co/cyberagent/dojo2020/ui/TextAdapter.kt
@@ -4,14 +4,14 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
-import jp.co.cyberagent.dojo2020.data.model.Memo
+import jp.co.cyberagent.dojo2020.data.model.*
 import jp.co.cyberagent.dojo2020.databinding.ItemMemoBinding
 import java.util.Collections.emptyList
 
-class MemoAdapter(private val onItemClickListener: View.OnClickListener) :
-    RecyclerView.Adapter<MemoAdapter.RecyclerViewHolder>() {
+class TextAdapter(private val onItemClickListener: View.OnClickListener) :
+    RecyclerView.Adapter<TextAdapter.RecyclerViewHolder>() {
 
-    var memoList: List<Memo> = emptyList()
+    var textList: List<Text> = emptyList()
         set(value) {
             field = value
             notifyDataSetChanged()
@@ -25,13 +25,26 @@ class MemoAdapter(private val onItemClickListener: View.OnClickListener) :
             itemView.setOnClickListener(onItemClickListener)
         }
 
-        fun setMemo(memo: Memo) {
+        fun setText(text: Text) {
             binding.apply {
-                titleTextView.text = memo.title
-                contentsTextView.text = memo.contents
-                timeChronometer.text = memo.time.toString()
-                categoryTextView.text = memo.category
+                titleTextView.text = text.title
+                contentsTextView.text = text.contents
+                categoryTextView.text = text.category
             }
+
+            when (text) {
+                is Left -> setDraft(text.value)
+                is Right -> setMemo(text.value)
+            }
+        }
+
+
+        private fun setDraft(draft: Draft) {
+
+        }
+
+        private fun setMemo(memo: Memo) {
+
         }
     }
 
@@ -43,13 +56,11 @@ class MemoAdapter(private val onItemClickListener: View.OnClickListener) :
     }
 
     override fun onBindViewHolder(holder: RecyclerViewHolder, position: Int) {
-        val memo = memoList[position]
+        val text = textList[position]
 
-        holder.setMemo(memo)
+        holder.setText(text)
         holder.setOnItemClickListener(onItemClickListener)
     }
 
-    override fun getItemCount() = memoList.size
-
-
+    override fun getItemCount() = textList.size
 }

--- a/app/src/main/java/jp/co/cyberagent/dojo2020/ui/home/HomeFragment.kt
+++ b/app/src/main/java/jp/co/cyberagent/dojo2020/ui/home/HomeFragment.kt
@@ -1,16 +1,15 @@
 package jp.co.cyberagent.dojo2020.ui.home
 
 import android.os.Bundle
-import android.util.Log
 import android.view.*
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.LinearLayoutManager
 import jp.co.cyberagent.dojo2020.R
+import jp.co.cyberagent.dojo2020.data.model.toText
 import jp.co.cyberagent.dojo2020.databinding.FragmentHomeBinding
-import jp.co.cyberagent.dojo2020.ui.MemoAdapter
-import jp.co.cyberagent.dojo2020.ui.widget.CustomBottomSheetDialog.Companion.TAG
+import jp.co.cyberagent.dojo2020.ui.TextAdapter
 
 class HomeFragment : Fragment() {
     private lateinit var binding: FragmentHomeBinding
@@ -46,15 +45,13 @@ class HomeFragment : Fragment() {
                 false
             )
 
-            val memoAdapter = MemoAdapter(View.OnClickListener {
-                Log.d(TAG, "selected")
-
+            val memoAdapter = TextAdapter {
                 val action = HomeFragmentDirections.actionHomeFragmentToMemoEditFragment("test_id")
                 findNavController().navigate(action)
-            })
+            }
 
-            homeViewModel.memoListLiveData.observe(viewLifecycleOwner) {
-                memoAdapter.memoList = it
+            homeViewModel.memoListLiveData.observe(viewLifecycleOwner) { memoList ->
+                memoAdapter.textList = memoList.map { it.toText() }
             }
 
             recyclerView.apply {
@@ -71,7 +68,7 @@ class HomeFragment : Fragment() {
     }
 
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        inflater.inflate(R.menu.menu_home,menu)
+        inflater.inflate(R.menu.menu_home, menu)
         super.onCreateOptionsMenu(menu, inflater)
     }
 
@@ -90,5 +87,5 @@ class HomeFragment : Fragment() {
             }
         }
     }
-    
+
 }


### PR DESCRIPTION
What did you do?
Textという型を受け取るAdapterを使うことでDraftであろうとMemoであろうと受け取れるようにした

How to do?
sealed classを使うことでパターンマッチで良しなにできるようにした
e.g)
`when (text) {`
`is Left -> text.value`
`is Right -> text.value`
`}`