### PR TITLE
Bug fix duplicate timer livedata

### DIFF
--- a/app/src/main/java/jp/co/cyberagent/dojo2020/data/FlowTimer.kt
+++ b/app/src/main/java/jp/co/cyberagent/dojo2020/data/FlowTimer.kt
@@ -1,11 +1,15 @@
 package jp.co.cyberagent.dojo2020.data
 
+import android.content.ContentValues.TAG
+import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.asLiveData
+import jp.co.cyberagent.dojo2020.data.timer.TimerDataSource
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.channels.awaitClose
-import kotlinx.coroutines.flow.callbackFlow
-import java.util.*
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 
-class FlowTimer {
+class FlowTimer private constructor() {
     private var isStarting = true
     private var differenceTime = 0L
 
@@ -18,26 +22,21 @@ class FlowTimer {
     }
 
     @ExperimentalCoroutinesApi
-    fun timerFlow(startTime: Long) = callbackFlow<Long> {
-        val timer = Timer()
-        var time = startTime
+    val timeFlow = TimerDataSource.timerFlow
+        .onEach { if (!isStarting) differenceTime++ }
+        .map { it - differenceTime }
 
-        timer.scheduleAtFixedRate(
-            object : TimerTask() {
-                override fun run() {
-                    try {
-                        if (isStarting) offer(time - differenceTime)
-                    } catch (exception: Exception) {
-                    }
+    companion object {
+        private val hashInstance = hashMapOf<String, LiveData<Long>>()
 
-                    time++
-                    if (!isStarting) differenceTime++
-                }
-            },
-            0,
-            1000L
-        )
+        @ExperimentalCoroutinesApi
+        fun instance(id: String) = hashInstance.getOrElse(id) {
+            Log.d(TAG, "[$id] first making")
+            FlowTimer()
+                .timeFlow
+                .asLiveData()
+                .also { hashInstance[id] = it }
 
-        awaitClose { timer.cancel() }
+        }.also { Log.d(TAG, "got instance") }
     }
 }

--- a/app/src/main/java/jp/co/cyberagent/dojo2020/data/FlowTimer.kt
+++ b/app/src/main/java/jp/co/cyberagent/dojo2020/data/FlowTimer.kt
@@ -1,7 +1,5 @@
 package jp.co.cyberagent.dojo2020.data
 
-import android.content.ContentValues.TAG
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.asLiveData
 import jp.co.cyberagent.dojo2020.data.timer.TimerDataSource
@@ -31,12 +29,7 @@ class FlowTimer private constructor() {
 
         @ExperimentalCoroutinesApi
         fun instance(id: String) = hashInstance.getOrElse(id) {
-            Log.d(TAG, "[$id] first making")
-            FlowTimer()
-                .timeFlow
-                .asLiveData()
-                .also { hashInstance[id] = it }
-
-        }.also { Log.d(TAG, "got instance") }
+            FlowTimer().timeFlow.asLiveData().also { hashInstance[id] = it }
+        }
     }
 }

--- a/app/src/main/java/jp/co/cyberagent/dojo2020/data/timer/TimerDataSource.kt
+++ b/app/src/main/java/jp/co/cyberagent/dojo2020/data/timer/TimerDataSource.kt
@@ -1,0 +1,29 @@
+package jp.co.cyberagent.dojo2020.data.timer
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.callbackFlow
+import java.util.*
+
+object TimerDataSource {
+
+    @ExperimentalCoroutinesApi
+    val timerFlow = callbackFlow<Long> {
+        val timer = Timer()
+        var time = 0L
+
+        timer.scheduleAtFixedRate(
+            object : TimerTask() {
+                override fun run() {
+                    try { offer(time) } catch (exception: Exception) { }
+
+                    time++
+                }
+            },
+            0,
+            1000L
+        )
+
+        awaitClose { timer.cancel() }
+    }
+}

--- a/app/src/main/java/jp/co/cyberagent/dojo2020/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/jp/co/cyberagent/dojo2020/ui/home/HomeViewModel.kt
@@ -3,6 +3,7 @@ package jp.co.cyberagent.dojo2020.ui.home
 import androidx.hilt.lifecycle.ViewModelInject
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
+import androidx.lifecycle.map
 import androidx.lifecycle.viewModelScope
 import jp.co.cyberagent.dojo2020.data.DraftRepository
 import jp.co.cyberagent.dojo2020.data.FlowTimer
@@ -27,7 +28,7 @@ class HomeViewModel @ViewModelInject constructor(
     val userLiveData = userFlow.asLiveData()
 
     @ExperimentalCoroutinesApi
-    fun timeLiveData(startTime: Long) = FlowTimer().timerFlow(startTime).asLiveData()
+    fun timeLiveData(id: String, startTime: Long) = FlowTimer.instance(id).map { it + startTime }
 
     @ExperimentalCoroutinesApi
     val textListLiveData = userFlow.flatMapLatest { userInfo ->

--- a/app/src/main/java/jp/co/cyberagent/dojo2020/ui/home/TextAdapter.kt
+++ b/app/src/main/java/jp/co/cyberagent/dojo2020/ui/home/TextAdapter.kt
@@ -1,5 +1,7 @@
 package jp.co.cyberagent.dojo2020.ui.home
 
+import android.content.ContentValues.TAG
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -95,15 +97,21 @@ class TextAdapter(
                 System.currentTimeMillis() - draft.startTime
             )
 
-            val timeLiveData = homeViewModel.timeLiveData(currentSeconds)
-            timeLiveData.observe(lifecycleOwner) { timeTextView.text = millsToFormattedTime(it) }
+            val timeLiveData = homeViewModel.timeLiveData(draft.id, currentSeconds)
+            timeLiveData.removeObservers(lifecycleOwner)
+            timeLiveData.observe(lifecycleOwner) {
+                timeTextView.text = millsToFormattedTime(it)
+            }
+            Log.d(TAG, timeLiveData.hashCode().toString())
 
             timerImageButton.setOnClickListener { view ->
                 view.isSelected = !view.isSelected
 
-                timeLiveData.value?.also {
-                    homeViewModel.saveMemo(draft.toMemo(it))
-                    homeViewModel.deleteDraft(draft)
+                if (view.isSelected) {
+                    timeLiveData.value?.also {
+                        homeViewModel.saveMemo(draft.toMemo(it))
+                        homeViewModel.deleteDraft(draft)
+                    }
                 }
 
                 (view as ImageButton).showImage(

--- a/app/src/main/java/jp/co/cyberagent/dojo2020/ui/home/TextAdapter.kt
+++ b/app/src/main/java/jp/co/cyberagent/dojo2020/ui/home/TextAdapter.kt
@@ -1,7 +1,5 @@
 package jp.co.cyberagent.dojo2020.ui.home
 
-import android.content.ContentValues.TAG
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -87,8 +85,10 @@ class TextAdapter(
             }
         }
 
+        @ExperimentalCoroutinesApi
         private fun setMemo(memo: Memo) = binding.apply {
             timeTextView.text = millsToFormattedTime(memo.time)
+            timerImageButton.showImage(this, isStoppingIcon)
         }
 
         @ExperimentalCoroutinesApi
@@ -97,27 +97,18 @@ class TextAdapter(
                 System.currentTimeMillis() - draft.startTime
             )
 
+            timerImageButton.showImage(this, isStartingIcon)
+
             val timeLiveData = homeViewModel.timeLiveData(draft.id, currentSeconds)
 
             timeLiveData.removeObservers(lifecycleOwner)
-            timeLiveData.observe(lifecycleOwner) {
-                timeTextView.text = millsToFormattedTime(it)
-            }
+            timeLiveData.observe(lifecycleOwner) { timeTextView.text = millsToFormattedTime(it) }
 
-            timerImageButton.setOnClickListener { view ->
-                view.isSelected = !view.isSelected
-
-                if (view.isSelected) {
-                    timeLiveData.value?.also {
-                        homeViewModel.saveMemo(draft.toMemo(it))
-                        homeViewModel.deleteDraft(draft)
-                    }
+            timerImageButton.setOnClickListener {
+                timeLiveData.value?.also {
+                    homeViewModel.saveMemo(draft.toMemo(it))
+                    homeViewModel.deleteDraft(draft)
                 }
-
-                (view as ImageButton).showImage(
-                    this,
-                    if (view.isSelected) isStartingIcon else isStoppingIcon
-                )
 
                 timeLiveData.removeObservers(lifecycleOwner)
             }

--- a/app/src/main/java/jp/co/cyberagent/dojo2020/ui/home/TextAdapter.kt
+++ b/app/src/main/java/jp/co/cyberagent/dojo2020/ui/home/TextAdapter.kt
@@ -98,11 +98,11 @@ class TextAdapter(
             )
 
             val timeLiveData = homeViewModel.timeLiveData(draft.id, currentSeconds)
+
             timeLiveData.removeObservers(lifecycleOwner)
             timeLiveData.observe(lifecycleOwner) {
                 timeTextView.text = millsToFormattedTime(it)
             }
-            Log.d(TAG, timeLiveData.hashCode().toString())
 
             timerImageButton.setOnClickListener { view ->
                 view.isSelected = !view.isSelected


### PR DESCRIPTION
What did you do? 
一つのタイマーが複数のLiveDataをObserveしていたのを直した

How do you do it?
LiveDataをmemoやdraftのidひとつにつき一つのものを生成することで、いま使っているLiveDataを取得できるようにして、
新たにObserveする際にはRemoveObserveすることで一つのObserverしかないという状況を作った